### PR TITLE
Remove reference to `global.nativeQPLTimestamp`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 const PerformanceNow =
   global.performanceNow ||
-  global.nativeQPLTimestamp ||
   global.nativePerformanceNow  ||
   require('fbjs/lib/performanceNow');
 


### PR DESCRIPTION
Upgrading to version 1.2.0 of the polyfill on React Native 0.57, when using `console.time` and `console.timeEnd`, the warning is always logged: "Timer '${label}' does not exist". This is because the console polyfill is using `global.nativeQPLTimestamp`, which is always returning zero.

React Native 0.51 removed the `QuickPerformanceLogger.java` class, which provides the implementation for the "QPL" functions such as `nativeQPLTimestamp`. The Java class was removed, but the JNI code still registers the global functions. However, the implementation of `global.nativeQPLTimestamp` just returns 0, since there is no Java implementation available.

I removed the use of this function from the polyfill since it appears that React Native is moving away from the QuickPerformanceLogger to use other systems.